### PR TITLE
chore: Dockerfile を廃止し compose.yml 一本化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,13 +47,14 @@ CSS のリンクは環境で切替（[hono/src/index.tsx](hono/src/index.tsx)）
 Bun はこの環境にネイティブ導入していない。**必ず Docker（`oven/bun`）経由**で動かす。
 
 ```
-make install   # docker compose build + bun install
-make up        # http://localhost:3000 （Vite dev, HMR）
+make install   # bun install（コンテナ内。node_modules は ./hono に作られる）
+make up         # http://localhost:3000 （Vite dev, HMR）
 make down
 make generate  # dist/ を生成（= bun run build）
 make logs
 ```
 
+- Dockerfile は無し。[compose.yml](compose.yml) が `image: oven/bun:1.4` を直接使い、`working_dir`/`command`/`ports` を指定するだけ
 - dev サーバは port **3000**（`vite.config.ts` で `server.host:true, port:3000`）
 - 直接叩く例: `docker run --rm -u 0 -v "$PWD/hono":/app oven/bun:1.4 sh -c "bun install && bun run build"`
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ down:
 	docker compose down
 
 install:
-	docker compose build
 	docker compose run --rm bun bun install
 
 logs:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+services:
+  bun:
+    image: oven/bun:1.4
+    working_dir: /app
+    command: bun run dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./hono:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,0 @@
-services:
-  bun:
-    build: ./docker/bun
-    ports:
-    - "3000:3000"
-    volumes:
-    - ./hono:/app

--- a/docker/bun/Dockerfile
+++ b/docker/bun/Dockerfile
@@ -1,5 +1,0 @@
-FROM oven/bun:1.4
-
-WORKDIR /app
-EXPOSE 3000
-CMD ["bun", "run", "dev"]


### PR DESCRIPTION
## 動機
`docker/bun/Dockerfile` は
```dockerfile
FROM oven/bun:1.4
WORKDIR /app
EXPOSE 3000
CMD ["bun", "run", "dev"]
```
だけで、中身はすべて compose 側で表現可能。Dockerfile と `build` ステップは過剰なので削除し、compose 一本化でシンプルにする。

## 変更
- `docker/bun/Dockerfile` と `docker/` を削除
- `docker-compose.yml` → **`compose.yml`**（現行標準名）にリネームし、`image: oven/bun:1.4` を直接使用（`working_dir` / `command` / `ports` / `volumes` を指定）
- `Makefile`: 不要になった `docker compose build` を `install` から削除
- `CLAUDE.md`: Dockerfile無し構成に更新

## 検証
- `docker compose config` が正しく解決
- `docker compose run --rm bun ...` で bun 1.4.0 / `pwd=/app` / `./hono` バインドマウントを確認

ローカル手順は不変: `make install` → `make up`（http://localhost:3000）→ `make generate`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)